### PR TITLE
🔀 Pull Request: Merge feature/attachments → main

### DIFF
--- a/link_exporter.py
+++ b/link_exporter.py
@@ -5,14 +5,14 @@ import csv
 import requests
 from bs4 import BeautifulSoup
 from datetime import datetime
-from utils.basecamp_api import fetch_todo_detail, fetch_comments
+from utils.basecamp_api import fetch_todo_detail, fetch_message_detail, fetch_comments
 
 # Load config
 with open("config.json", "r") as f:
     config = json.load(f)
 
 ACCESS_TOKEN = config.get("access_token")
-ACCOUNT_ID = str(config.get("account_id"))  # must be string for URL formatting
+ACCOUNT_ID = str(config.get("account_id"))
 
 HEADERS = {
     "Authorization": f"Bearer {ACCESS_TOKEN}",
@@ -26,17 +26,24 @@ output_dir = os.path.join("results", f"run_{timestamp}")
 os.makedirs(output_dir, exist_ok=True)
 
 
-def parse_todo_url(url):
-    match = re.search(r'/(?:projects|buckets)/(\d+)/todos/(\d+)', url)
+def determine_link_type(url):
+    if re.search(r'/buckets/\d+/todos/\d+', url):
+        return "todo"
+    elif re.search(r'/buckets/\d+/messages/\d+', url):
+        return "message"
+    return "unknown"
+
+
+def parse_ids(url, link_type):
+    match = re.search(r'/buckets/(\d+)/(?:todos|messages)/(\d+)', url)
     if not match:
-        raise ValueError("URL must contain /projects|buckets/{project_id}/todos/{todo_id}")
+        raise ValueError(f"URL must contain /buckets/{{id}}/{link_type}/{{id}}")
     return match.group(1), match.group(2)
 
 
 def clean_html(raw_html):
     soup = BeautifulSoup(raw_html or "", "html.parser")
-    text = soup.get_text()
-    return re.sub(r'\s+', ' ', text).strip()  # normalize all whitespace
+    return re.sub(r'\s+', ' ', soup.get_text()).strip()
 
 
 def format_comments(comments):
@@ -46,112 +53,134 @@ def format_comments(comments):
         created_at = c.get("created_at", "")[:19].replace("T", " ")
         text = clean_html(c.get("content", ""))
         if text:
-            line = f"[{author} - {created_at}]: {text}"
-            formatted.append(line.replace('\n', ' ').replace('\r', ' ').strip())
-    return "\n".join(formatted)
+            block = f"{author} [{created_at}]\n{text}\n"
+            formatted.append(block)
+    return "\n\n".join(formatted).strip()
 
 
-def export_to_csv(todo_data, comments, output_csv):
+def export_to_csv(data, comments, output_csv, is_todo=True):
     with open(output_csv, "w", newline="", encoding="utf-8") as f:
         writer = csv.writer(f)
-        writer.writerow(["Project Name", "Todolist Name", "Todo Title", "Assignee", "Description", "Comments"])
+        writer.writerow(["Project Name", "Container Name", "Title", "Assignee", "Description", "Comments"])
 
-        project_name = todo_data.get("bucket", {}).get("name", "")
-        todolist_name = todo_data.get("parent", {}).get("title", "")
-        title = todo_data.get("title", "")
-        description = clean_html(todo_data.get("description", ""))
+        project_name = data.get("bucket", {}).get("name", "")
+        container = data.get("parent", {}).get("title", "") if is_todo else data.get("title", "")
+        title = data.get("title", "")
+        description = clean_html(data.get("description", "") if is_todo else data.get("content", ""))
 
-        assignees = [a.get("name", "") for a in todo_data.get("assignees", [])]
+        assignees = [a.get("name", "") for a in data.get("assignees", [])] if is_todo else []
         assignee_str = ", ".join(assignees)
 
         comments_str = format_comments(comments)
 
-        writer.writerow([project_name, todolist_name, title, assignee_str, description, comments_str])
+        writer.writerow([project_name, container, title, assignee_str, description, comments_str])
 
 
-def save_json(data, filepath):
-    with open(filepath, "w", encoding="utf-8") as f:
+def save_json(data, path):
+    with open(path, "w", encoding="utf-8") as f:
         json.dump(data, f, indent=2, ensure_ascii=False)
 
 
-def download_attachments(todo_data, comments, attachments_root):
-    os.makedirs(attachments_root, exist_ok=True)
+def should_skip_download(url):
+    return "avatar" in url or "/people/" in url
 
-    def extract_and_download(html, save_dir, prefix=""):
-        soup = BeautifulSoup(html or "", "html.parser")
-        for i, tag in enumerate(soup.find_all("bc-attachment")):
-            url = tag.get("href") or tag.get("url")
-            filename = tag.get("filename") or f"{prefix}_attachment_{i+1}"
 
-            if not url or not filename:
-                continue
+def extract_and_download(html, save_dir, prefix=""):
+    soup = BeautifulSoup(html or "", "html.parser")
+    img_tags = soup.find_all("img")
 
-            try:
-                response = requests.get(url, headers=HEADERS, stream=True)
-                content_type = response.headers.get("Content-Type", "")
+    for i, tag in enumerate(img_tags):
+        url = tag.get("src")
+        if not url:
+            continue
 
-                print(f"[INFO] Attempting to download: {filename} ({url}) — {content_type}")
+        filename = f"{prefix}_img_{i+1}.png"
+        if should_skip_download(url):
+            print(f"[SKIP] Ignored (avatar or preview): {filename} ({url})")
+            continue
 
-                if response.status_code == 200 and "html" not in content_type.lower():
-                    os.makedirs(save_dir, exist_ok=True)
-                    filepath = os.path.join(save_dir, filename)
-                    with open(filepath, "wb") as f:
-                        for chunk in response.iter_content(chunk_size=8192):
-                            if chunk:
-                                f.write(chunk)
-                    print(f"[OK] Saved to: {filepath}")
-                else:
-                    print(f"[WARN] Skipped (non-binary or failed): {filename} ({response.status_code})")
+        try:
+            response = requests.get(url, headers=HEADERS, stream=True)
+            content_type = response.headers.get("Content-Type", "")
+            print(f"[INFO] Attempting to download: {filename} ({url}) — {content_type}")
 
-            except Exception as e:
-                print(f"[ERROR] Exception downloading {url}: {e}")
+            if response.status_code == 200 and "html" not in content_type.lower():
+                os.makedirs(save_dir, exist_ok=True)
+                with open(os.path.join(save_dir, filename), "wb") as f:
+                    for chunk in response.iter_content(chunk_size=8192):
+                        if chunk:
+                            f.write(chunk)
+                print(f"[OK] Saved to: {os.path.join(save_dir, filename)}")
+            else:
+                print(f"[WARN] Skipped (non-binary or failed): {filename} ({response.status_code})")
 
-    # From description
-    desc_dir = os.path.join(attachments_root, "description")
-    extract_and_download(todo_data.get("description", ""), desc_dir, "desc")
+        except Exception as e:
+            print(f"[ERROR] Exception downloading {url}: {e}")
+
+
+def download_attachments(body_html, comments, root_dir):
+    os.makedirs(root_dir, exist_ok=True)
+
+    # From main body
+    desc_dir = os.path.join(root_dir, "description")
+    extract_and_download(body_html, desc_dir, "description")
 
     # From comments
     for c in comments:
-        comment_id = c.get("id")
-        content = c.get("content", "")
-        comment_dir = os.path.join(attachments_root, f"comment_{comment_id}")
-        extract_and_download(content, comment_dir, f"comment_{comment_id}")
+        cid = c.get("id")
+        comment_html = c.get("content", "")
+        comment_dir = os.path.join(root_dir, f"comment_{cid}")
+        extract_and_download(comment_html, comment_dir, f"comment_{cid}")
+
+
+def handle_todo(bucket_id, todo_id):
+    print(f"[INFO] Fetching To-do {todo_id}...")
+    todo_data = fetch_todo_detail(ACCOUNT_ID, bucket_id, int(todo_id), HEADERS)
+    comments = fetch_comments(ACCOUNT_ID, bucket_id, int(todo_id), HEADERS)
+
+    if not todo_data:
+        print("[ERROR] Failed to fetch To-do.")
+        return
+
+    save_json({"todo": todo_data, "comments": comments}, os.path.join(output_dir, f"todo_{todo_id}.json"))
+    export_to_csv(todo_data, comments, os.path.join(output_dir, f"todo_{todo_id}_jira.csv"), is_todo=True)
+    download_attachments(todo_data.get("description", ""), comments, os.path.join(output_dir, "attachments"))
+
+
+def handle_message(bucket_id, message_id):
+    print(f"[INFO] Fetching Message {message_id}...")
+    message_data = fetch_message_detail(ACCOUNT_ID, bucket_id, int(message_id), HEADERS)
+    comments = fetch_comments(ACCOUNT_ID, bucket_id, int(message_id), HEADERS)
+
+    if not message_data:
+        print("[ERROR] Failed to fetch Message.")
+        return
+
+    save_json({"message": message_data, "comments": comments}, os.path.join(output_dir, f"message_{message_id}.json"))
+    export_to_csv(message_data, comments, os.path.join(output_dir, f"message_{message_id}_jira.csv"), is_todo=False)
+    download_attachments(message_data.get("content", ""), comments, os.path.join(output_dir, "attachments"))
 
 
 def main():
-    todo_url = input("Enter full Basecamp To-do URL: ").strip()
+    url = input("Enter full Basecamp To-do or Message URL: ").strip()
+    link_type = determine_link_type(url)
+
+    if link_type == "unknown":
+        print("[ERROR] Unsupported URL format.")
+        return
 
     try:
-        project_id, todo_id = parse_todo_url(todo_url)
+        bucket_id, item_id = parse_ids(url, link_type)
     except ValueError as e:
-        print(f"[ERROR] Invalid URL format: {e}")
+        print(f"[ERROR] {e}")
         return
 
-    print(f"Fetching To-do {todo_id} from project {project_id}...")
+    if link_type == "todo":
+        handle_todo(bucket_id, item_id)
+    elif link_type == "message":
+        handle_message(bucket_id, item_id)
 
-    todo_data = fetch_todo_detail(ACCOUNT_ID, project_id, int(todo_id), HEADERS)
-    comments_data = fetch_comments(ACCOUNT_ID, project_id, int(todo_id), HEADERS)
-
-    if not todo_data:
-        print("[ERROR] Failed to fetch To-do. Aborting.")
-        return
-
-    result = {
-        "todo": todo_data,
-        "comments": comments_data
-    }
-
-    json_path = os.path.join(output_dir, f"todo_{todo_id}.json")
-    csv_path = os.path.join(output_dir, f"todo_{todo_id}_jira.csv")
-    attachments_dir = os.path.join(output_dir, "attachments")
-
-    save_json(result, json_path)
-    export_to_csv(todo_data, comments_data, csv_path)
-    download_attachments(todo_data, comments_data, attachments_dir)
-
-    print(f"[SUCCESS] Exported JSON: {json_path}")
-    print(f"[SUCCESS] Exported CSV : {csv_path}")
-    print(f"[SUCCESS] Attachments saved in: {attachments_dir}")
+    print(f"[SUCCESS] Export complete: {output_dir}")
 
 
 if __name__ == "__main__":

--- a/utils/basecamp_api.py
+++ b/utils/basecamp_api.py
@@ -1,4 +1,5 @@
 import requests
+import re
 from utils.utils import print_error
 
 BASE_URL = "https://3.basecampapi.com"
@@ -13,12 +14,33 @@ def fetch_todo_detail(account_id: str, bucket_id: str, todo_id: int, headers: di
         print_error(f"[TODO FETCH FAIL] {todo_id}: {e}")
         return None
 
-def fetch_comments(account_id: str, bucket_id: str, todo_id: int, headers: dict) -> list[dict]:
+def fetch_comments(account_id: str, bucket_id: str, item_id: int, headers: dict) -> list[dict]:
+    all_comments = []
+    base_url = f"{BASE_URL}/{account_id}/buckets/{bucket_id}/recordings/{item_id}/comments.json"
+    url = base_url
+
+    while url:
+        try:
+            res = requests.get(url, headers=headers)
+            res.raise_for_status()
+            all_comments.extend(res.json())
+
+            # Handle pagination using the Link header
+            link_header = res.headers.get("Link", "")
+            match = re.search(r'<([^>]+)>;\s*rel="next"', link_header)
+            url = match.group(1) if match else None
+        except Exception as e:
+            print_error(f"[COMMENTS FETCH FAIL] {item_id}: {e}")
+            break
+
+    return all_comments
+    
+def fetch_message_detail(account_id: str, bucket_id: str, message_id: int, headers: dict) -> dict | None:
     try:
-        url = f"{BASE_URL}/{account_id}/buckets/{bucket_id}/recordings/{todo_id}/comments.json"
+        url = f"{BASE_URL}/{account_id}/buckets/{bucket_id}/messages/{message_id}.json"
         res = requests.get(url, headers=headers)
         res.raise_for_status()
         return res.json()
     except Exception as e:
-        print_error(f"[COMMENTS FETCH FAIL] {todo_id}: {e}")
-        return []   
+        print_error(f"[MESSAGE FETCH FAIL] {message_id}: {e}")
+        return None


### PR DESCRIPTION
✅ Summary
This PR introduces major enhancements to the Basecamp export tool, including support for:

- 🧩 Group-aware To-do enrichment (using groups.json)
- 📎 Attachment extraction and organization
- 📄 Improved Jira-compatible CSV formatting
- 🔧 General code refactoring and modularization

🆕 Key Features & Changes
1. fetch.py
- Enriched fetch_and_append_todos() to:
  - Fetch and map group_id to group name using groups.json
  - Append group info into todo records
- Handles edge cases with fallback to "Ungrouped"

2. jira_formatter.py
- Updated to include:
  - Group column in the final CSV
  - More detailed comment formatting
  - Attachment name+link formatting

3. basecamp_api.py
- Modularized and improved API calls:
  - fetch_todo_detail(), fetch_message_detail(), fetch_comments()
  - Centralized Basecamp endpoint handling with better error logs

4. link_exporter.py
- Downloads all attachments from:
  - To-do descriptions
  - To-do comments
- Skips avatars & HTML errors using content-type validation
- Saves into: results/run_<timestamp>/attachments/
- JSON + CSV output with cleaned metadata

⚠️ Limitations
- Grouped todos still require admin access to certain endpoints (e.g., recordings.json) for full fidelity.
- Binary downloads rely on public or temporarily valid links from Basecamp.

📂 Output Examples
- ✅ todos_deep.json — enriched todos with group and attachment metadata
- ✅ todos_jira.csv — clean export for Jira import
- ✅ attachments/ — downloaded assets (with fallback logging for failures)